### PR TITLE
Add Flask system info webapp

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,27 @@
 # sysinfo
-Systeminformationen über das gesamte System
+
+Dieses Repository stellt eine kleine Flask-Webanwendung bereit, die Systeminformationen grafisch aufbereitet anzeigt. Zusätzlich gibt es ein Shell-Skript, das die gleichen Informationen in der Konsole ausgibt.
+
+## Voraussetzungen
+
+Python 3 und pip müssen installiert sein. Anschließend Flask installieren:
+
+```bash
+pip install Flask
+```
+
+## Starten der Webanwendung
+
+```bash
+python app.py
+```
+
+Danach im Browser <http://localhost:5000> aufrufen.
+
+## Alternativ: Skript in der Konsole
+
+```bash
+bash sysinfo.sh
+```
+
+Das Skript gibt Informationen zu Betriebssystem, Distribution, CPU, Arbeitsspeicher, Festplattenbelegung und Netzwerkadressen aus.

--- a/app.py
+++ b/app.py
@@ -1,0 +1,37 @@
+from flask import Flask, render_template
+import subprocess
+import shutil
+
+app = Flask(__name__)
+
+def run_cmd(cmd):
+    try:
+        return subprocess.check_output(cmd, shell=True, text=True).strip()
+    except subprocess.CalledProcessError as e:
+        return e.output.strip() if e.output else str(e)
+
+def get_sysinfo():
+    info = {}
+    info['System'] = run_cmd('uname -a')
+    if shutil.which('lsb_release'):
+        info['Distribution'] = run_cmd('lsb_release -a')
+    else:
+        info['Distribution'] = 'lsb_release not available'
+    cpu_model = run_cmd("grep -m1 'model name' /proc/cpuinfo")
+    cpu_cores = run_cmd('nproc --all')
+    info['CPU'] = f"{cpu_model}\nCores: {cpu_cores}"
+    info['Memory'] = run_cmd('free -h')
+    info['Disk'] = run_cmd('df -h')
+    if shutil.which('ip'):
+        info['Network'] = run_cmd("ip -o -4 addr show | awk '{print $2, $4}'")
+    else:
+        info['Network'] = run_cmd('hostname -I')
+    return info
+
+@app.route('/')
+def index():
+    data = get_sysinfo()
+    return render_template('index.html', data=data)
+
+if __name__ == '__main__':
+    app.run(host='0.0.0.0', port=5000)

--- a/sysinfo.sh
+++ b/sysinfo.sh
@@ -1,0 +1,32 @@
+#!/bin/bash
+# Print comprehensive system information
+
+print_section() {
+  echo "=============================="
+  echo "$1"
+  echo "=============================="
+}
+
+print_section "System"
+uname -a
+
+print_section "Distribution"
+if command -v lsb_release >/dev/null 2>&1; then
+  lsb_release -a
+else
+  echo "lsb_release not available"
+fi
+
+print_section "CPU"
+grep -m1 "model name" /proc/cpuinfo
+nproc --all
+
+print_section "Memory"
+free -h
+
+print_section "Disk"
+df -h
+
+print_section "Network"
+ip -o -4 addr show | awk '{print $2, $4}'
+

--- a/templates/index.html
+++ b/templates/index.html
@@ -1,0 +1,24 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>System Information</title>
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css" rel="stylesheet">
+  </head>
+  <body class="bg-light">
+    <div class="container py-4">
+      <h1 class="mb-4">System Information</h1>
+      {% for section, content in data.items() %}
+        <div class="card mb-3">
+          <div class="card-header bg-primary text-white">
+            {{ section }}
+          </div>
+          <div class="card-body">
+            <pre class="mb-0">{{ content }}</pre>
+          </div>
+        </div>
+      {% endfor %}
+    </div>
+  </body>
+</html>


### PR DESCRIPTION
## Summary
- add Flask-based web server with Bootstrap template
- provide HTML template for modern layout
- update README with instructions for running the web app

## Testing
- `FLASK_APP=app.py FLASK_RUN_PORT=5050 flask run &` then `curl -s http://127.0.0.1:5050 | head`


------
https://chatgpt.com/codex/tasks/task_e_6859161065a88321b8ce743a620cfba5