### PR TITLE
Add network speed test

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,13 +1,13 @@
 # sysinfo
 
-Dieses Repository stellt eine kleine Flask-Webanwendung bereit, die Systeminformationen grafisch aufbereitet anzeigt. Die Speicherauslastung und Festplattenbelegung werden dabei als Fortschrittsbalken dargestellt. Zusätzlich gibt es ein Shell-Skript, das die gleichen Informationen in der Konsole ausgibt.
+Dieses Repository stellt eine kleine Flask-Webanwendung bereit, die Systeminformationen grafisch aufbereitet anzeigt. Die Speicherauslastung und Festplattenbelegung werden dabei als Fortschrittsbalken dargestellt. Zusätzlich gibt es ein Shell-Skript, das die gleichen Informationen in der Konsole ausgibt. Beide Varianten können optional einen Geschwindigkeitstest des Netzwerks ausführen.
 
 ## Voraussetzungen
 
-Python 3 und pip müssen installiert sein. Anschließend Flask installieren:
+Python 3 und pip müssen installiert sein. Anschließend Flask sowie speedtest-cli installieren:
 
 ```bash
-pip install Flask
+pip install Flask speedtest-cli
 ```
 
 ## Starten der Webanwendung
@@ -25,3 +25,4 @@ bash sysinfo.sh
 ```
 
 Das Skript gibt Informationen zu Betriebssystem, Distribution, CPU, Arbeitsspeicher, Festplattenbelegung und Netzwerkadressen aus.
+Wenn `speedtest-cli` installiert ist, wird außerdem ein kurzer Geschwindigkeitstest durchgeführt.

--- a/sysinfo.sh
+++ b/sysinfo.sh
@@ -30,3 +30,10 @@ df -h
 print_section "Network"
 ip -o -4 addr show | awk '{print $2, $4}'
 
+print_section "Speedtest"
+if command -v speedtest-cli >/dev/null 2>&1; then
+  speedtest-cli --simple
+else
+  echo "speedtest-cli not available"
+fi
+

--- a/templates/index.html
+++ b/templates/index.html
@@ -30,6 +30,13 @@
                 </div>
               {% endfor %}
               <pre class="mb-0">{{ content.raw }}</pre>
+            {% elif section == 'Speedtest' and content is mapping %}
+              <ul class="list-unstyled mb-2">
+                <li><strong>Ping:</strong> {{ content.ping }}</li>
+                <li><strong>Download:</strong> {{ content.download }}</li>
+                <li><strong>Upload:</strong> {{ content.upload }}</li>
+              </ul>
+              <pre class="mb-0">{{ content.raw }}</pre>
             {% else %}
               <pre class="mb-0">{{ content }}</pre>
             {% endif %}


### PR DESCRIPTION
## Summary
- include optional speedtest section in web UI
- show speedtest output in shell script
- update README with instructions to install `speedtest-cli`

## Testing
- `python -m py_compile app.py`
- `bash -n sysinfo.sh`
- `speedtest-cli --simple | head -n 5`

------
https://chatgpt.com/codex/tasks/task_e_68591a1ab90c83219b774ebb4e60ae43