### PR TITLE
Use Frankfurt server for speedtests

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,4 +25,4 @@ bash sysinfo.sh
 ```
 
 Das Skript gibt Informationen zu Betriebssystem, Distribution, CPU, Arbeitsspeicher, Festplattenbelegung und Netzwerkadressen aus.
-Wenn `speedtest-cli` installiert ist, wird außerdem ein kurzer Geschwindigkeitstest durchgeführt.
+Wenn `speedtest-cli` installiert ist, wird außerdem ein kurzer Geschwindigkeitstest durchgeführt. Dabei wird ein Server in der Nähe von Frankfurt genutzt (Server-ID `32412`).

--- a/app.py
+++ b/app.py
@@ -110,7 +110,8 @@ def get_sysinfo():
     info['Memory'] = parse_memory(mem_output)
     info['Disk'] = parse_disk(disk_output)
     if shutil.which('speedtest-cli'):
-        speedtest_output = run_cmd('speedtest-cli --simple')
+        # Use a server located near Frankfurt for more consistent results
+        speedtest_output = run_cmd('speedtest-cli --simple --server 32412')
         info['Speedtest'] = parse_speedtest(speedtest_output)
     else:
         info['Speedtest'] = 'speedtest-cli not available'

--- a/sysinfo.sh
+++ b/sysinfo.sh
@@ -32,7 +32,8 @@ ip -o -4 addr show | awk '{print $2, $4}'
 
 print_section "Speedtest"
 if command -v speedtest-cli >/dev/null 2>&1; then
-  speedtest-cli --simple
+  # Use a server located near Frankfurt
+  speedtest-cli --simple --server 32412
 else
   echo "speedtest-cli not available"
 fi


### PR DESCRIPTION
## Summary
- run speedtests against a Frankfurt server (ID 32412)
- document Frankfurt server usage in README

## Testing
- `python -m py_compile app.py`
- `bash -n sysinfo.sh`
- `python - <<'EOF'
import app
print(app.get_sysinfo()['Speedtest'])
EOF`
- `bash sysinfo.sh > /tmp/shell.log 2>&1 && cat /tmp/shell.log`


------
https://chatgpt.com/codex/tasks/task_e_68591c5d6b2c83219568be2449ee207b