### PR TITLE
Improve speedtest fallback

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,4 +25,4 @@ bash sysinfo.sh
 ```
 
 Das Skript gibt Informationen zu Betriebssystem, Distribution, CPU, Arbeitsspeicher, Festplattenbelegung und Netzwerkadressen aus.
-Wenn `speedtest-cli` installiert ist, wird außerdem ein kurzer Geschwindigkeitstest durchgeführt. Dabei wird ein Server in der Nähe von Frankfurt genutzt (Server-ID `32412`).
+Ist `speedtest-cli` vorhanden, versucht es nun automatisch mehrere Server aus Deutschland (z.B. `68177`, `60421`, `59653`, `64665` und `68164`). Schlägt jeder Versuch fehl, wird ersatzweise ein Ping-Test ausgeführt.

--- a/app.py
+++ b/app.py
@@ -110,9 +110,18 @@ def get_sysinfo():
     info['Memory'] = parse_memory(mem_output)
     info['Disk'] = parse_disk(disk_output)
     if shutil.which('speedtest-cli'):
-        # Use a server located near Frankfurt for more consistent results
-        speedtest_output = run_cmd('speedtest-cli --simple --server 32412')
-        info['Speedtest'] = parse_speedtest(speedtest_output)
+        servers = ['68177', '60421', '59653', '64665', '68164']
+        speed_data = None
+        for sid in servers:
+            out = run_cmd(f'speedtest-cli --simple --server {sid}')
+            if 'Cannot retrieve speedtest configuration' not in out and 'ERROR' not in out:
+                speed_data = parse_speedtest(out)
+                break
+        if speed_data:
+            info['Speedtest'] = speed_data
+        else:
+            fallback = run_cmd('ping -c 4 google.com')
+            info['Speedtest'] = {'raw': fallback}
     else:
         info['Speedtest'] = 'speedtest-cli not available'
     if shutil.which('ip'):

--- a/sysinfo.sh
+++ b/sysinfo.sh
@@ -32,8 +32,21 @@ ip -o -4 addr show | awk '{print $2, $4}'
 
 print_section "Speedtest"
 if command -v speedtest-cli >/dev/null 2>&1; then
-  # Use a server located near Frankfurt
-  speedtest-cli --simple --server 32412
+  # Try several German servers in case one fails
+  SERVERS=(68177 60421 59653 64665 68164)
+  SUCCESS=false
+  for SID in "${SERVERS[@]}"; do
+    echo "Testing with server $SID..."
+    if speedtest-cli --simple --server "$SID"; then
+      SUCCESS=true
+      break
+    fi
+    echo "Server $SID failed, trying next..." >&2
+  done
+  if [ "$SUCCESS" = false ]; then
+    echo "Speedtest failed. Running ping as fallback." >&2
+    ping -c 4 google.com
+  fi
 else
   echo "speedtest-cli not available"
 fi


### PR DESCRIPTION
## Summary
- try multiple German servers for speedtest-cli
- fall back to ping when speedtest fails
- document new behaviour in README

## Testing
- `bash sysinfo.sh > /tmp/sys.log`
- `python - <<'PY'
from app import get_sysinfo
import json
print(json.dumps(get_sysinfo(), indent=2))
PY
`

------
https://chatgpt.com/codex/tasks/task_e_68591da0b29c8321bc6f55a80db870f6