### PR TITLE
Improve speedtest fallback

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,4 +25,5 @@ bash sysinfo.sh
 ```
 
 Das Skript gibt Informationen zu Betriebssystem, Distribution, CPU, Arbeitsspeicher, Festplattenbelegung und Netzwerkadressen aus.
-Ist `speedtest-cli` vorhanden, versucht es nun automatisch mehrere Server aus Deutschland (z.B. `68177`, `60421`, `59653`, `64665` und `68164`). Schlägt jeder Versuch fehl, wird ersatzweise ein Ping-Test ausgeführt.
+Ist `speedtest-cli` vorhanden, wird nacheinander versucht, mehrere deutsche Server zu nutzen (z.B. `68177`, `60421`, `59653`, `64665` und `68164`).
+Schlagen alle fehl, erfolgt ein weiterer Versuch ohne Vorgabe eines Servers. Erst wenn auch dieser scheitert, wird ersatzweise ein Ping-Test ausgeführt.

--- a/app.py
+++ b/app.py
@@ -117,6 +117,10 @@ def get_sysinfo():
             if 'Cannot retrieve speedtest configuration' not in out and 'ERROR' not in out:
                 speed_data = parse_speedtest(out)
                 break
+        if not speed_data:
+            auto_out = run_cmd('speedtest-cli --simple')
+            if 'Cannot retrieve speedtest configuration' not in auto_out and 'ERROR' not in auto_out:
+                speed_data = parse_speedtest(auto_out)
         if speed_data:
             info['Speedtest'] = speed_data
         else:

--- a/sysinfo.sh
+++ b/sysinfo.sh
@@ -28,7 +28,11 @@ print_section "Disk"
 df -h
 
 print_section "Network"
-ip -o -4 addr show | awk '{print $2, $4}'
+if command -v ip >/dev/null 2>&1; then
+  ip -o -4 addr show | awk '{print $2, $4}'
+else
+  echo "ip command not available"
+fi
 
 print_section "Speedtest"
 if command -v speedtest-cli >/dev/null 2>&1; then
@@ -43,6 +47,12 @@ if command -v speedtest-cli >/dev/null 2>&1; then
     fi
     echo "Server $SID failed, trying next..." >&2
   done
+  if [ "$SUCCESS" = false ]; then
+    echo "All preset servers failed, trying automatic selection..." >&2
+    if speedtest-cli --simple; then
+      SUCCESS=true
+    fi
+  fi
   if [ "$SUCCESS" = false ]; then
     echo "Speedtest failed. Running ping as fallback." >&2
     ping -c 4 google.com


### PR DESCRIPTION
## Summary
- handle missing `ip` command in shell script
- attempt automatic speedtest server selection when preset servers fail
- do the same in the Flask app
- document new behaviour in README

## Testing
- `bash sysinfo.sh > /tmp/out.txt && tail -n 20 /tmp/out.txt`
- `python app.py` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_685920ade27083218007989ce623c957