### PR TITLE
Add sysinfo API endpoint

### DIFF
--- a/app.py
+++ b/app.py
@@ -1,4 +1,4 @@
-from flask import Flask, render_template
+from flask import Flask, jsonify, render_template
 import subprocess
 import shutil
 import re
@@ -149,6 +149,16 @@ def get_sysinfo():
 def index():
     data = get_sysinfo()
     return render_template('index.html', data=data)
+
+
+@app.route('/api/sysinfo')
+def api_sysinfo():
+    data = get_sysinfo()
+    response = jsonify(data)
+    response.headers['Cache-Control'] = 'no-store, max-age=0, must-revalidate'
+    response.headers['Pragma'] = 'no-cache'
+    response.headers['Expires'] = '0'
+    return response
 
 if __name__ == '__main__':
     app.run(host='0.0.0.0', port=8015)


### PR DESCRIPTION
## Summary
- add a `/api/sysinfo` endpoint that returns system info as JSON using `get_sysinfo`
- disable caching on the new endpoint with appropriate headers for polling or streaming use
- import `jsonify` to build the API response

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692f5d69b3908321bfff0ce5f3ec8057)