### PR TITLE
Add live dashboard charts for system info

### DIFF
--- a/static/js/dashboard.js
+++ b/static/js/dashboard.js
@@ -1,0 +1,252 @@
+const chartColors = {
+  cpu: ['#d9534f', '#5cb85c'],
+  memory: ['#0275d8', '#5bc0de'],
+  disk: ['#5bc0de'],
+  networkRx: '#6f42c1',
+  networkTx: '#f0ad4e',
+};
+
+const charts = {};
+let lastNetworkTotals = null;
+let lastNetworkTimestamp = null;
+const maxNetworkPoints = 20;
+
+function formatBytes(bytes) {
+  if (bytes === 0) return '0 B/s';
+  const sizes = ['B/s', 'KiB/s', 'MiB/s', 'GiB/s'];
+  const i = Math.min(Math.floor(Math.log(bytes) / Math.log(1024)), sizes.length - 1);
+  const value = bytes / 1024 ** i;
+  return `${value.toFixed(1)} ${sizes[i]}`;
+}
+
+function initCpuChart(ctx) {
+  charts.cpu = new Chart(ctx, {
+    type: 'doughnut',
+    data: {
+      labels: ['Genutzt', 'Idle'],
+      datasets: [
+        {
+          data: [0, 100],
+          backgroundColor: chartColors.cpu,
+          hoverOffset: 8,
+        },
+      ],
+    },
+    options: {
+      responsive: true,
+      plugins: {
+        tooltip: {
+          callbacks: {
+            label: (context) => `${context.label}: ${context.parsed.toFixed(1)}%`,
+          },
+        },
+        legend: { position: 'bottom' },
+      },
+      cutout: '60%',
+    },
+  });
+}
+
+function initMemoryChart(ctx) {
+  charts.memory = new Chart(ctx, {
+    type: 'doughnut',
+    data: {
+      labels: ['Belegt', 'Frei'],
+      datasets: [
+        {
+          data: [0, 100],
+          backgroundColor: chartColors.memory,
+          hoverOffset: 8,
+        },
+      ],
+    },
+    options: {
+      responsive: true,
+      plugins: {
+        tooltip: {
+          callbacks: {
+            label: (context) => `${context.label}: ${context.parsed.toFixed(1)}%`,
+          },
+        },
+        legend: { position: 'bottom' },
+      },
+      cutout: '60%',
+    },
+  });
+}
+
+function initDiskChart(ctx) {
+  charts.disk = new Chart(ctx, {
+    type: 'bar',
+    data: {
+      labels: [],
+      datasets: [
+        {
+          label: 'Belegt',
+          data: [],
+          backgroundColor: 'rgba(0, 123, 255, 0.5)',
+          borderColor: '#007bff',
+          borderWidth: 1,
+        },
+      ],
+    },
+    options: {
+      responsive: true,
+      scales: {
+        y: {
+          beginAtZero: true,
+          max: 100,
+          ticks: {
+            callback: (value) => `${value}%`,
+          },
+        },
+      },
+      plugins: {
+        tooltip: {
+          callbacks: {
+            label: (context) => `${context.raw}%` ,
+          },
+        },
+        legend: { display: false },
+      },
+    },
+  });
+}
+
+function initNetworkChart(ctx) {
+  charts.network = new Chart(ctx, {
+    type: 'line',
+    data: {
+      labels: [],
+      datasets: [
+        {
+          label: 'RX',
+          data: [],
+          borderColor: chartColors.networkRx,
+          backgroundColor: 'rgba(111, 66, 193, 0.2)',
+          tension: 0.3,
+          fill: true,
+        },
+        {
+          label: 'TX',
+          data: [],
+          borderColor: chartColors.networkTx,
+          backgroundColor: 'rgba(240, 173, 78, 0.2)',
+          tension: 0.3,
+          fill: true,
+        },
+      ],
+    },
+    options: {
+      responsive: true,
+      interaction: { intersect: false, mode: 'index' },
+      scales: {
+        y: {
+          beginAtZero: true,
+          ticks: {
+            callback: (value) => formatBytes(value),
+          },
+        },
+      },
+      plugins: {
+        tooltip: {
+          callbacks: {
+            label: (context) => `${context.dataset.label}: ${formatBytes(context.parsed.y)}`,
+          },
+        },
+        legend: { position: 'bottom' },
+      },
+    },
+  });
+}
+
+function updateCpuChart(cpu) {
+  if (!charts.cpu || !cpu) return;
+  const used = cpu.usage?.usage ?? 0;
+  charts.cpu.data.datasets[0].data = [used, Math.max(0, 100 - used)];
+  charts.cpu.update();
+}
+
+function updateMemoryChart(memory) {
+  if (!charts.memory || !memory) return;
+  const used = memory.percent || 0;
+  charts.memory.data.datasets[0].data = [used, Math.max(0, 100 - used)];
+  charts.memory.update();
+}
+
+function updateDiskChart(disk) {
+  if (!charts.disk || !disk) return;
+  const labels = (disk.entries || []).map((entry) => `${entry.mount}`);
+  const values = (disk.entries || []).map((entry) => entry.percent);
+  charts.disk.data.labels = labels;
+  charts.disk.data.datasets[0].data = values;
+  charts.disk.update();
+}
+
+function updateNetworkChart(networkStats) {
+  if (!charts.network || !networkStats) return;
+  const now = Date.now();
+
+  if (lastNetworkTotals && lastNetworkTimestamp) {
+    const deltaSeconds = (now - lastNetworkTimestamp) / 1000;
+    if (deltaSeconds > 0) {
+      const rxRate = (networkStats.rx_bytes - lastNetworkTotals.rx_bytes) / deltaSeconds;
+      const txRate = (networkStats.tx_bytes - lastNetworkTotals.tx_bytes) / deltaSeconds;
+      const label = new Date().toLocaleTimeString();
+
+      charts.network.data.labels.push(label);
+      charts.network.data.datasets[0].data.push(Math.max(0, rxRate));
+      charts.network.data.datasets[1].data.push(Math.max(0, txRate));
+
+      if (charts.network.data.labels.length > maxNetworkPoints) {
+        charts.network.data.labels.shift();
+        charts.network.data.datasets.forEach((dataset) => dataset.data.shift());
+      }
+
+      charts.network.update();
+    }
+  }
+
+  lastNetworkTotals = { rx_bytes: networkStats.rx_bytes, tx_bytes: networkStats.tx_bytes };
+  lastNetworkTimestamp = now;
+}
+
+async function fetchData() {
+  const response = await fetch('/api/sysinfo');
+  if (!response.ok) throw new Error('Fehler beim Abrufen der Systemdaten');
+  return response.json();
+}
+
+function updateTimestamp() {
+  const target = document.getElementById('lastUpdated');
+  const timestamp = new Date().toLocaleTimeString();
+  if (target) {
+    target.textContent = `Zuletzt aktualisiert: ${timestamp}`;
+  }
+}
+
+async function pollData() {
+  try {
+    const data = await fetchData();
+    updateCpuChart(data.CPU);
+    updateMemoryChart(data.Memory);
+    updateDiskChart(data.Disk);
+    updateNetworkChart(data.NetworkStats);
+    updateTimestamp();
+  } catch (error) {
+    console.error(error);
+  }
+}
+
+function initCharts() {
+  initCpuChart(document.getElementById('cpuChart'));
+  initMemoryChart(document.getElementById('memoryChart'));
+  initDiskChart(document.getElementById('diskChart'));
+  initNetworkChart(document.getElementById('networkChart'));
+}
+
+window.addEventListener('DOMContentLoaded', () => {
+  initCharts();
+  pollData();
+  setInterval(pollData, 8000);
+});

--- a/templates/index.html
+++ b/templates/index.html
@@ -5,16 +5,63 @@
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <title>System Information</title>
     <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css" rel="stylesheet">
+    <style>
+      .chart-card {
+        min-height: 320px;
+      }
+
+      canvas {
+        max-height: 240px;
+      }
+    </style>
   </head>
   <body class="bg-light">
     <div class="container py-4">
-      <h1 class="mb-4">System Information</h1>
-      {% for section, content in data.items() %}
-        <div class="card mb-3">
-          <div class="card-header bg-primary text-white">
-            {{ section }}
+      <div class="d-flex flex-column flex-md-row align-items-md-center justify-content-between mb-4 gap-2">
+        <h1 class="mb-0">System Information</h1>
+        <span class="text-muted" id="lastUpdated">&nbsp;</span>
+      </div>
+
+      <div class="row g-3 mb-4">
+        <div class="col-md-6 col-lg-3">
+          <div class="card chart-card h-100 shadow-sm">
+            <div class="card-header bg-primary text-white">CPU</div>
+            <div class="card-body d-flex align-items-center justify-content-center">
+              <canvas id="cpuChart" aria-label="CPU usage chart" role="img"></canvas>
+            </div>
           </div>
-          <div class="card-body">
+        </div>
+        <div class="col-md-6 col-lg-3">
+          <div class="card chart-card h-100 shadow-sm">
+            <div class="card-header bg-success text-white">RAM</div>
+            <div class="card-body d-flex align-items-center justify-content-center">
+              <canvas id="memoryChart" aria-label="Memory usage chart" role="img"></canvas>
+            </div>
+          </div>
+        </div>
+        <div class="col-md-6 col-lg-3">
+          <div class="card chart-card h-100 shadow-sm">
+            <div class="card-header bg-info text-white">Disk</div>
+            <div class="card-body d-flex align-items-center justify-content-center">
+              <canvas id="diskChart" aria-label="Disk usage chart" role="img"></canvas>
+            </div>
+          </div>
+        </div>
+        <div class="col-md-6 col-lg-3">
+          <div class="card chart-card h-100 shadow-sm">
+            <div class="card-header bg-warning text-dark">Netzwerk</div>
+            <div class="card-body d-flex align-items-center justify-content-center">
+              <canvas id="networkChart" aria-label="Network throughput chart" role="img"></canvas>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      <div class="card mb-3 shadow-sm">
+        <div class="card-header bg-secondary text-white">Details</div>
+        <div class="card-body">
+          {% for section, content in data.items() %}
+            <h5 class="mt-3">{{ section }}</h5>
             {% if section == 'Memory' %}
               <div class="progress mb-2" style="height: 20px;">
                 <div class="progress-bar" role="progressbar" style="width: {{ content.percent }}%;" aria-valuenow="{{ content.percent }}" aria-valuemin="0" aria-valuemax="100">
@@ -30,6 +77,10 @@
                 </div>
               {% endfor %}
               <pre class="mb-0">{{ content.raw }}</pre>
+            {% elif section == 'CPU' and content is mapping %}
+              <p class="mb-1"><strong>Modell:</strong> {{ content.model }}</p>
+              <p class="mb-1"><strong>Kerne:</strong> {{ content.cores }}</p>
+              <pre class="mb-0">Auslastung: {{ content.usage.usage }}% (Idle: {{ content.usage.idle }}%)</pre>
             {% elif section == 'Speedtest' and content is mapping %}
               <ul class="list-unstyled mb-2">
                 <li><strong>Ping:</strong> {{ content.ping }}</li>
@@ -40,9 +91,15 @@
             {% else %}
               <pre class="mb-0">{{ content }}</pre>
             {% endif %}
-          </div>
+            {% if not loop.last %}
+              <hr>
+            {% endif %}
+          {% endfor %}
         </div>
-      {% endfor %}
+      </div>
     </div>
+
+    <script src="https://cdn.jsdelivr.net/npm/chart.js@4.4.4/dist/chart.umd.min.js" integrity="sha256-hAldh1srDElcQ9lYHr2pEexQm2hxUiOR3hnbyNnXkHY=" crossorigin="anonymous"></script>
+    <script type="module" src="{{ url_for('static', filename='js/dashboard.js') }}"></script>
   </body>
 </html>


### PR DESCRIPTION
## Summary
- add CPU usage calculation and network byte counters to the system info API payload
- refresh the index template with responsive chart cards for CPU, memory, disk, and network metrics
- implement a Chart.js dashboard module that polls `/api/sysinfo` and updates visuals with tooltips and color scales

## Testing
- python -m compileall .

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692f5e12730c83218549926cb107b2e7)