### PR TITLE
Enhance dashboard layout with KPI grid and theme toggle

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -6,50 +6,219 @@
     <title>System Information</title>
     <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css" rel="stylesheet">
     <style>
+      :root {
+        --bg: #f6f7fb;
+        --card-bg: #ffffff;
+        --text-main: #1f2933;
+        --text-muted: #6b7280;
+        --accent: #2563eb;
+        --accent-soft: rgba(37, 99, 235, 0.12);
+        --border: #e5e7eb;
+        --shadow: 0 10px 30px rgba(15, 23, 42, 0.08);
+      }
+
+      [data-theme="dark"] {
+        --bg: #0f172a;
+        --card-bg: #111827;
+        --text-main: #e5e7eb;
+        --text-muted: #9ca3af;
+        --accent: #60a5fa;
+        --accent-soft: rgba(96, 165, 250, 0.15);
+        --border: #1f2937;
+        --shadow: 0 12px 36px rgba(0, 0, 0, 0.45);
+      }
+
+      body {
+        background: var(--bg);
+        color: var(--text-main);
+        transition: background-color 0.3s ease, color 0.3s ease;
+      }
+
+      .content-shell {
+        max-width: 1200px;
+      }
+
+      .glass-card {
+        background: var(--card-bg);
+        border: 1px solid var(--border);
+        box-shadow: var(--shadow);
+        border-radius: 16px;
+      }
+
+      .soft-pill {
+        background: var(--accent-soft);
+        color: var(--accent);
+        border: 1px solid var(--accent);
+        border-radius: 50px;
+        padding: 0.35rem 0.75rem;
+        font-weight: 600;
+        display: inline-flex;
+        gap: 0.35rem;
+        align-items: center;
+      }
+
+      .live-dot {
+        width: 12px;
+        height: 12px;
+        display: inline-block;
+        border-radius: 50%;
+        background: #10b981;
+        box-shadow: 0 0 0 0 rgba(16, 185, 129, 0.6);
+        animation: pulse 1.6s ease-in-out infinite;
+      }
+
+      @keyframes pulse {
+        0% {
+          transform: scale(0.95);
+          box-shadow: 0 0 0 0 rgba(16, 185, 129, 0.6);
+        }
+        70% {
+          transform: scale(1);
+          box-shadow: 0 0 0 15px rgba(16, 185, 129, 0);
+        }
+        100% {
+          transform: scale(0.95);
+          box-shadow: 0 0 0 0 rgba(16, 185, 129, 0);
+        }
+      }
+
+      .kpi-card {
+        border-radius: 14px;
+        padding: 1.25rem;
+        background: var(--card-bg);
+        border: 1px solid var(--border);
+        box-shadow: var(--shadow);
+        height: 100%;
+      }
+
+      .kpi-label {
+        color: var(--text-muted);
+        font-size: 0.95rem;
+        margin-bottom: 0.25rem;
+      }
+
+      .kpi-value {
+        font-size: 1.75rem;
+        font-weight: 700;
+      }
+
+      .card-header {
+        border-bottom: 0;
+        background: transparent;
+        padding-bottom: 0;
+      }
+
       .chart-card {
-        min-height: 320px;
+        min-height: 340px;
       }
 
       canvas {
         max-height: 240px;
       }
+
+      .theme-toggle {
+        border-radius: 12px;
+        border: 1px solid var(--border);
+        background: var(--card-bg);
+        color: var(--text-main);
+        padding: 0.45rem 0.85rem;
+        box-shadow: var(--shadow);
+      }
+
+      .timestamp {
+        color: var(--text-muted);
+        font-weight: 600;
+      }
     </style>
   </head>
-  <body class="bg-light">
-    <div class="container py-4">
-      <div class="d-flex flex-column flex-md-row align-items-md-center justify-content-between mb-4 gap-2">
-        <h1 class="mb-0">System Information</h1>
-        <span class="text-muted" id="lastUpdated">&nbsp;</span>
+  <body data-theme="light">
+    <div class="container py-4 content-shell">
+      <div class="d-flex flex-column flex-md-row align-items-md-center justify-content-between mb-4 gap-3">
+        <div class="d-flex align-items-center gap-3">
+          <div>
+            <p class="text-uppercase text-muted small mb-1 fw-semibold">System Dashboard</p>
+            <h1 class="mb-0">System Information</h1>
+          </div>
+          <span class="soft-pill" aria-label="Live status">
+            <span class="live-dot"></span>
+            Live
+          </span>
+        </div>
+        <div class="d-flex align-items-center gap-3">
+          <span class="timestamp" id="lastUpdated">Letzte Aktualisierung: –</span>
+          <button id="themeToggle" class="btn theme-toggle" type="button" aria-label="Dark or light theme toggle">
+            🌙 Dark
+          </button>
+        </div>
+      </div>
+
+      <div class="row g-3 mb-4">
+        <div class="col-sm-6 col-lg-3">
+          <div class="kpi-card">
+            <div class="kpi-label">CPU-Auslastung</div>
+            <div class="kpi-value" id="cpuUsageValue">–</div>
+            <div class="text-muted">Nutzung gesamt</div>
+          </div>
+        </div>
+        <div class="col-sm-6 col-lg-3">
+          <div class="kpi-card">
+            <div class="kpi-label">RAM-Auslastung</div>
+            <div class="kpi-value" id="ramUsageValue">–</div>
+            <div class="text-muted">Belegt in %</div>
+          </div>
+        </div>
+        <div class="col-sm-6 col-lg-3">
+          <div class="kpi-card">
+            <div class="kpi-label">Plattennutzung</div>
+            <div class="kpi-value" id="diskUsageValue">–</div>
+            <div class="text-muted">Höchster Mount</div>
+          </div>
+        </div>
+        <div class="col-sm-6 col-lg-3">
+          <div class="kpi-card">
+            <div class="kpi-label">Netzwerk IP</div>
+            <div class="kpi-value" id="networkIpValue">–</div>
+            <div class="text-muted">Aktive Adresse</div>
+          </div>
+        </div>
       </div>
 
       <div class="row g-3 mb-4">
         <div class="col-md-6 col-lg-3">
-          <div class="card chart-card h-100 shadow-sm">
-            <div class="card-header bg-primary text-white">CPU</div>
+          <div class="card glass-card chart-card h-100 p-3">
+            <div class="card-header pb-2">
+              <h5 class="card-title mb-0">CPU</h5>
+            </div>
             <div class="card-body d-flex align-items-center justify-content-center">
               <canvas id="cpuChart" aria-label="CPU usage chart" role="img"></canvas>
             </div>
           </div>
         </div>
         <div class="col-md-6 col-lg-3">
-          <div class="card chart-card h-100 shadow-sm">
-            <div class="card-header bg-success text-white">RAM</div>
+          <div class="card glass-card chart-card h-100 p-3">
+            <div class="card-header pb-2">
+              <h5 class="card-title mb-0">RAM</h5>
+            </div>
             <div class="card-body d-flex align-items-center justify-content-center">
               <canvas id="memoryChart" aria-label="Memory usage chart" role="img"></canvas>
             </div>
           </div>
         </div>
         <div class="col-md-6 col-lg-3">
-          <div class="card chart-card h-100 shadow-sm">
-            <div class="card-header bg-info text-white">Disk</div>
+          <div class="card glass-card chart-card h-100 p-3">
+            <div class="card-header pb-2">
+              <h5 class="card-title mb-0">Disk</h5>
+            </div>
             <div class="card-body d-flex align-items-center justify-content-center">
               <canvas id="diskChart" aria-label="Disk usage chart" role="img"></canvas>
             </div>
           </div>
         </div>
         <div class="col-md-6 col-lg-3">
-          <div class="card chart-card h-100 shadow-sm">
-            <div class="card-header bg-warning text-dark">Netzwerk</div>
+          <div class="card glass-card chart-card h-100 p-3">
+            <div class="card-header pb-2">
+              <h5 class="card-title mb-0">Netzwerk</h5>
+            </div>
             <div class="card-body d-flex align-items-center justify-content-center">
               <canvas id="networkChart" aria-label="Network throughput chart" role="img"></canvas>
             </div>
@@ -57,9 +226,11 @@
         </div>
       </div>
 
-      <div class="card mb-3 shadow-sm">
-        <div class="card-header bg-secondary text-white">Details</div>
-        <div class="card-body">
+      <div class="card glass-card mb-3 p-3">
+        <div class="card-header pb-2">
+          <h5 class="card-title mb-0">Details</h5>
+        </div>
+        <div class="card-body pt-2">
           {% for section, content in data.items() %}
             <h5 class="mt-3">{{ section }}</h5>
             {% if section == 'Memory' %}


### PR DESCRIPTION
## Summary
- add KPI grid with live status badge and theme toggle to the dashboard
- refresh chart layout with soft card styling and dark/light CSS variables
- surface last update timestamp alongside KPI values updated by polling

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692f5f34e30c8321bd592f8d08219995)